### PR TITLE
Fix to match file casing of source files when discovered by DBH.exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [4.9.2] - 2024-01-04
+
+### Changed
+
+- fix to match file casing of source files when discovered by DBH.exe, otherwise test Uris don't exactly match open files in VSCode.
+- fix for TAEF test filter arguments not being correct when running a subset of selected tests.
+
 ## [4.9.0] - 2023-12-30
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "vscode-catch2-test-adapter",
-  "version": "4.7.0",
+  "name": "vscode-taef-test-adapter",
+  "version": "4.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vscode-catch2-test-adapter",
-      "version": "4.7.0",
+      "name": "vscode-taef-test-adapter",
+      "version": "4.9.2",
       "license": "MIT",
       "dependencies": {
         "@types/htmlparser2": "^3.10.7",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "resources/icon.png",
   "author": "Mate Pek",
   "publisher": "dpar39",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "license": "MIT",
   "homepage": "https://github.com/dpar39/vscode-catch2-test-adapter",
   "repository": {

--- a/src/framework/AbstractExecutable.ts
+++ b/src/framework/AbstractExecutable.ts
@@ -831,7 +831,7 @@ export abstract class AbstractExecutable<TestT extends AbstractTest = AbstractTe
     if (typeof file != 'string') return undefined;
 
     // normalize before apply resolvedSourceFileMap because it is normalize too
-    // this is for better platfrom independent resolution
+    // this is for better platform independent resolution
     let resolved = pathlib.normalize(file);
 
     for (const m in this.shared.resolvedSourceFileMap) {


### PR DESCRIPTION
…, otherwise test Uris don't exactly match open files in VSCode.

- fix for TAEF test filter arguments not being correct when running a subset of selected tests.

<!--
  Thanks for sending a pull request!  Here are some tips for you:
  Please read: https://github.com/matepek/vscode-catch2-test-adapter/blob/master/CONTRIBUTING.md

  Checklist:
  - Are the tests are running? (`npm test`)
  - Is the `CHANGELOG.md` was updated?
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
  Example: Fixes #23, Fixes #24
-->

**Special notes for your reviewer**:
